### PR TITLE
Add markdown in additional sections and filter it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4415,6 +4415,11 @@
         "domelementtype": "1"
       }
     },
+    "dompurify": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.2.7.tgz",
+      "integrity": "sha512-jdtDffdGNY+C76jvodNTu9jt5yYj59vuTUyx+wXdzcSwAGTYZDAQkQ7Iwx9zcGrA4ixC1syU4H3RZROqRxokxg=="
+    },
     "domutils": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cronstrue": "^1.108.0",
     "datatables-bulma": "^1.0.1",
     "datatables-bulma-jquery": "0.0.1",
+    "dompurify": "^2.2.7",
     "font-awesome": "^4.7.0",
     "jquery": "^3.5.1",
     "jquery-datatables-checkboxes": "^1.2.12",

--- a/src/report/finding/finding.vue
+++ b/src/report/finding/finding.vue
@@ -13,7 +13,7 @@ Copyright 2021 Adevinta
             <hr />
           </div>
           <div>
-            <VueShowdown :markdown="propsFindingDetail.row.issue.description" />
+            <VueShowdown :markdown="propsFindingDetail.row.issue.description" :extensions="['htmlSanitize']" />
           </div>
           <hr />
           <table class="table is-striped is-fullwidth">
@@ -56,7 +56,9 @@ Copyright 2021 Adevinta
                     v-for="recommendation in propsFindingDetail.row.issue.recommendations"
                     :key="recommendation"
                   >
-                    <td>{{ recommendation }}</td>
+                    <td>
+                      <VueShowdown :markdown="recommendation" :extensions="['htmlSanitize']" />
+                    </td>
                   </tr>
                 </table>
               </td>
@@ -95,7 +97,9 @@ Copyright 2021 Adevinta
                     <th v-for="header in resource.attributes">{{ header }}</th>
                   </thead>
                   <tr v-for="(row) in resource.resources">
-                    <td v-for="header in resource.attributes">{{ row[header] }}</td>
+                    <td v-for="header in resource.attributes">
+                      <VueShowdown :markdown="row[header]" :extensions="['htmlSanitize','noBlockquote']" />
+                    </td>
                   </tr>
                 </table>
               </td>

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -5,10 +5,10 @@ Copyright 2021 Adevinta
 import Vue from 'vue';
 import report from './report.vue';
 import { CreateElement } from 'vue';
-
 import { ConfigProgrammatic, Table, Input, Switch, Button, Icon, Field, Datepicker, Tabs, Select, Collapse, Message, Tag } from 'buefy';
 import VueShowdown from 'vue-showdown';
-
+import { VueShowdownPlugin, showdown } from 'vue-showdown';
+import DOMPurify from 'dompurify';
 
 // import 'buefy/dist/buefy.css';
 // Import styles
@@ -36,9 +36,28 @@ Vue.use(Message);
 Vue.use(Tag);
 Vue.use(VueShowdown, {
 	options: {
-	  emoji: true
-	}
+	  simpleLineBreaks: false,
+	  literalMidWordUnderscores: false,
+	},
   });
+
+VueShowdown.showdown.extension('htmlSanitize', () => [
+  {
+    type: 'output',
+    filter: function (text, converter, options) {
+      return DOMPurify.sanitize(text);
+    }
+  },
+]);
+
+// Prevent strings such as "> 2 years" from being interpreted as a quotation block.
+VueShowdown.showdown.extension('noBlockquote', () => [
+  {
+    type: 'lang',
+    regex: /(?<!<.*)>/g,
+    replace: '&gt;'
+  },
+]);
 
 Vue.config.productionTip = false;
 const app = new Vue({

--- a/src/report/report.ts
+++ b/src/report/report.ts
@@ -37,7 +37,7 @@ Vue.use(Tag);
 Vue.use(VueShowdown, {
 	options: {
 	  simpleLineBreaks: false,
-	  literalMidWordUnderscores: false,
+	  literalMidWordUnderscores: true,
 	},
   });
 


### PR DESCRIPTION
It also fixes issues with literal underscores in the middle of a word being incorrectly interpreted as markdown.
Additionally, Showdown extensions have been implemented to:
- Clean output HTML with [DOMPurify](https://github.com/cure53/DOMPurify) to prevent accidental code injection.
- Avoid interpreting ">" symbols in the resources table as quotation blocks.

Before:
![image](https://user-images.githubusercontent.com/7050335/114555503-0d622600-9c68-11eb-8a91-389ba24035f7.png)

After:
![image](https://user-images.githubusercontent.com/7050335/114555550-18b55180-9c68-11eb-91ca-66381452e2a5.png)