### PR TITLE
Change base docker image to unprivileged:alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ADD . .
 
 RUN npm run-script build
 
-FROM nginx:alpine
+FROM nginxinc/nginx-unprivileged:alpine
 
 ARG BUILD_RFC3339="1970-01-01T00:00:00Z"
 ARG COMMIT="local"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,10 @@ ARG COMMIT="local"
 ENV BUILD_RFC3339 "$BUILD_RFC3339"
 ENV COMMIT "$COMMIT"
 
-COPY --from=builder /app/dist /usr/share/nginx/html
+COPY --chown=nginx --from=builder /app/dist /usr/share/nginx/html
 
 WORKDIR /app
-
-COPY run.sh .
-COPY config.json .
+COPY --chown=nginx run.sh .
+COPY --chown=nginx config.json .
 
 CMD ["./run.sh"]

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ The command supposes the swagger file is in ```../vulcan-api/docs``` and is exec
 
 |Variable|Description|Sample|
 |---|---|---|
-|VULCAN_API||http://localhost:8080/api|
-|PORT|Port to listen|Defaults to 80|
+|VULCAN_API||http://localhost:8081/api|
+|PORT|Port to listen|Defaults to 8080|
 |UI_DOCS_API_LINK|Link to Vulcan API user docs|Defaults to UI root page|
 |UI_DOCS_WHITELISTING_LINK|Link to Vulcan scanner IPs|Defaults to UI root page|
 |UI_DOCS_DISCOVERY_LINK|Link to asset discovery documentation|Defaults to UI root page|
@@ -64,5 +64,5 @@ docker build . -t vui
 docker run --env-file ./local.env vui
 
 # Or set the variable
-docker run --env API_URL="http://localhost:8080/api" -p 8080:80 vui
+docker run --env API_URL="http://localhost:8081/api" -p 8080:8080 vui
 ```

--- a/run.sh
+++ b/run.sh
@@ -11,9 +11,9 @@ export UI_CONTACT_EMAIL=${UI_CONTACT_EMAIL:-}
 export UI_CONTACT_SLACK=${UI_CONTACT_SLACK:-/}
 
 # Apply env variables
-cat config.json | envsubst > /usr/share/nginx/html/config.json
-cat /usr/share/nginx/html/index.html | envsubst > tmp && mv tmp /usr/share/nginx/html/index.html
-cat /usr/share/nginx/html/assets/index.html | envsubst > tmp && mv tmp /usr/share/nginx/html/assets/index.html
+envsubst < config.json > /usr/share/nginx/html/config.json
+envsubst < /usr/share/nginx/html/index.html | tee /usr/share/nginx/html/index.html
+envsubst < /usr/share/nginx/html/assets/index.html | tee /usr/share/nginx/html/assets/index.html
 
 if echo "$PORT" | grep -Eq '[0-9]+'; then
   sed -i "s/^[[:space:]]\+listen .*/    listen $PORT;/g" /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
This PR change base docker image from `nginx:alpine` to `nginxinc/nginx-unprivileged:alpine` in order to be able to run Vulcan UI in a more restrictive K8S security context.

Changes in file ownership and environment configuration are required due to security context restrictions.