### PR TITLE
Live report: fix teams selector

### DIFF
--- a/src/report/findingview/findingview.vue
+++ b/src/report/findingview/findingview.vue
@@ -78,10 +78,6 @@ export default class FindingView extends Vue {
       },
   }
 
-  async activated() {
-    this.$emit('toggleUserListTeams', false);
-  }
-
   async mounted() {
     try {
       // Load the config.
@@ -108,6 +104,8 @@ export default class FindingView extends Vue {
       );
     } catch (err) {
       this.$emit('handleerror', err);
+    } finally {
+      this.$emit('toggleUserListTeams', false);
     }
   }
 

--- a/src/report/home/home.vue
+++ b/src/report/home/home.vue
@@ -653,10 +653,6 @@ export default class Home extends Vue {
   private severityText = severityText
   private statusClass = statusClass
 
-  async activated() {
-    this.$emit('toggleUserListTeams', true);
-  }
-
   async mounted() {
     try {
       // Load the config.
@@ -696,6 +692,7 @@ export default class Home extends Vue {
     } catch (err) {
       this.$emit('handleerror', err);
     } finally {
+      this.$emit('toggleUserListTeams', true);
       this.loading = false;
     }
   }


### PR DESCRIPTION
The Teams Selector combo box that appears at the top of the Live Report must be enabled on the main view (the one showing the list of findings of a team) and disabled when viewing a specific finding (via the direct link).

This mechanism is currently not working properly in production. 

This PR fixes the issue.