### PR TITLE
Hackaweek: Show findings for a subset of assets

### DIFF
--- a/src/report/home/home.vue
+++ b/src/report/home/home.vue
@@ -217,6 +217,7 @@ Copyright 2021 Adevinta
                         :minDate="this.minDate"
                         :maxDate="this.maxDate"
                         :atDate="this.atDate"
+                        :identifiers="this.identifiers"
                         mode="issue"
 
                         mainListDescriptionColumnHeader="Issue"
@@ -258,6 +259,7 @@ Copyright 2021 Adevinta
                         :minDate="this.minDate"
                         :maxDate="this.maxDate"
                         :atDate="this.atDate"
+                        :identifiers="this.identifiers"
                         mode="target"
 
                         mainListDescriptionColumnHeader="Asset"
@@ -375,6 +377,8 @@ export default class Home extends Vue {
   private minDate: Date = null;
   private maxDate: Date = null;
   
+  private identifiers: string = "";
+
   // Issues
   private dataIssues: ListItem[] = [];
   private totalIssues: number = 0;
@@ -436,6 +440,8 @@ export default class Home extends Vue {
       } else {
         this.modeSelect="digest";
       }
+      this.identifiers = qparams.get('identifiers') || ""
+      console.log("qparams.get('identifiers'): "+qparams.get('this.identifiers'))
 
       if (qparams.get('status')=="FIXED") {
         this.modeSelect="FIXED";
@@ -456,6 +462,7 @@ export default class Home extends Vue {
       minDate: this.minDate ? this.dateToStr(this.minDate) : undefined,
       maxDate: this.maxDate ? this.dateToStr(this.maxDate) : undefined,
       atDate: this.atDate ? this.dateToStr(this.atDate) : undefined,
+      identifiers: this.identifiers,
     };
     if (this.dateToStr(this.atDate)==this.dateToStr(new Date())){
       req.atDate=undefined;
@@ -490,6 +497,7 @@ export default class Home extends Vue {
       minDate: this.minDate ? this.dateToStr(this.minDate) : undefined,
       maxDate: this.maxDate ? this.dateToStr(this.maxDate) : undefined,
       atDate: this.atDate ? this.dateToStr(this.atDate) : undefined,
+      identifiers: this.identifiers,
     };
     if (this.dateToStr(this.atDate)==this.dateToStr(new Date())){
       issuesReq.atDate=undefined;
@@ -517,6 +525,7 @@ export default class Home extends Vue {
       minDate: this.minDate ? this.dateToStr(this.minDate) : undefined,
       maxDate: this.maxDate ? this.dateToStr(this.maxDate) : undefined,
       atDate: this.atDate ? this.dateToStr(this.atDate) : undefined,
+      identifiers: this.identifiers,
     };
     if (this.dateToStr(this.atDate)==this.dateToStr(new Date())){
       assetsReq.atDate=undefined;
@@ -544,6 +553,7 @@ export default class Home extends Vue {
       minDate: this.minDate ? this.dateToStr(this.minDate) : undefined,
       maxDate: this.maxDate ? this.dateToStr(this.maxDate) : undefined,
       atDate: this.atDate ? this.dateToStr(this.atDate) : undefined,
+      identifiers: this.identifiers,
     };
     if (this.dateToStr(this.atDate)==this.dateToStr(new Date())){
       issuesReq.atDate=undefined;
@@ -585,6 +595,7 @@ export default class Home extends Vue {
       minDate: this.minDate ? this.dateToStr(this.minDate) : undefined,
       maxDate: this.maxDate ? this.dateToStr(this.maxDate) : undefined,
       atDate: this.atDate ? this.dateToStr(this.atDate) : undefined,
+      identifiers: this.identifiers,
     };
     if (this.dateToStr(this.atDate)==this.dateToStr(new Date())){
       assetsReq.atDate=undefined;

--- a/src/report/home/home.vue
+++ b/src/report/home/home.vue
@@ -471,7 +471,6 @@ export default class Home extends Vue {
         this.modeSelect="digest";
       }
       this.identifiers = qparams.get('identifiers') || ""
-      console.log("qparams.get('identifiers'): "+qparams.get('this.identifiers'))
 
       if (qparams.get('status')=="FIXED") {
         this.modeSelect="FIXED";

--- a/src/report/home/home.vue
+++ b/src/report/home/home.vue
@@ -6,18 +6,48 @@ Copyright 2021 Adevinta
     <div>
         <div class="container">
         <div class="columns" v-if="modeSelect == 'fixed'">
-            <div class="column has-text-white" style="background: purple; font-size: 36; text-align: center;" >{{ statsFixed && statsFixed.fixedIssues ? statsFixed.fixedIssues.critical : "-" }}</div>
-            <div class="column has-text-white" style="background: red; font-size: 36;    text-align: center;">{{ statsFixed && statsFixed.fixedIssues ? statsFixed.fixedIssues.high : "-" }}</div>
-            <div class="column has-text-white" style="background: orange; font-size: 36; text-align: center;" >{{ statsFixed && statsFixed.fixedIssues ? statsFixed.fixedIssues.medium : "-" }}</div>
-            <div class="column has-text-dark"  style="background: hsl(48, 100%, 67%); font-size: 36; text-align: center;">{{ statsFixed && statsFixed.fixedIssues ? statsFixed.fixedIssues.low : "-" }}</div>
-            <div class="column has-text-white" style="background: hsl(204, 86%, 53%); font-size: 36; text-align: center;">{{ statsFixed && statsFixed.fixedIssues ? statsFixed.fixedIssues.informational : "-" }}</div>
+            <div class="column has-text-white" style="background: purple; font-size: 36; text-align: center;" >
+                {{ statsFixed && statsFixed.fixedIssues ? statsFixed.fixedIssues.critical : "-" }}
+                <div style="font-size: 14;">Critical</div>
+            </div>
+            <div class="column has-text-white" style="background: red; font-size: 36;    text-align: center;">
+                {{ statsFixed && statsFixed.fixedIssues ? statsFixed.fixedIssues.high : "-" }}
+                <div style="font-size: 14;">High</div>
+            </div>
+            <div class="column has-text-white" style="background: orange; font-size: 36; text-align: center;" >
+                {{ statsFixed && statsFixed.fixedIssues ? statsFixed.fixedIssues.medium : "-" }}
+                <div style="font-size: 14;">Medium</div>
+            </div>
+            <div class="column has-text-dark"  style="background: hsl(48, 100%, 67%); font-size: 36; text-align: center;">
+                {{ statsFixed && statsFixed.fixedIssues ? statsFixed.fixedIssues.low : "-" }}
+                <div style="font-size: 14;">Low</div>
+            </div>
+            <div class="column has-text-white" style="background: hsl(204, 86%, 53%); font-size: 36; text-align: center;">
+                {{ statsFixed && statsFixed.fixedIssues ? statsFixed.fixedIssues.informational : "-" }}
+                <div style="font-size: 14;">Informational</div>
+            </div>
         </div>
         <div class="columns" v-else>
-            <div class="column has-text-white" style="background: purple; font-size: 36; text-align: center;" >{{ statsOpen.openIssues ? statsOpen.openIssues.critical : "-" }}</div>
-            <div class="column has-text-white" style="background: red; font-size: 36;    text-align: center;">{{ statsOpen.openIssues ? statsOpen.openIssues.high : "-" }}</div>
-            <div class="column has-text-white" style="background: orange; font-size: 36; text-align: center;" >{{ statsOpen.openIssues ? statsOpen.openIssues.medium : "-" }}</div>
-            <div class="column has-text-dark"  style="background: hsl(48, 100%, 67%); font-size: 36; text-align: center;">{{ statsOpen.openIssues ? statsOpen.openIssues.low : "-" }}</div>
-            <div class="column has-text-white" style="background: hsl(204, 86%, 53%); font-size: 36; text-align: center;">{{ statsOpen.openIssues ? statsOpen.openIssues.informational : "-" }}</div>
+            <div class="column has-text-white" style="background: purple; font-size: 36; text-align: center;">
+                {{ statsOpen.openIssues ? statsOpen.openIssues.critical : "-" }}
+                <div style="font-size: 14;">Critical</div>
+            </div>
+            <div class="column has-text-white" style="background: red; font-size: 36; text-align: center;">
+                {{ statsOpen.openIssues ? statsOpen.openIssues.high : "-" }}
+                <div style="font-size: 14;">High</div>
+            </div>
+            <div class="column has-text-white" style="background: orange; font-size: 36; text-align: center;" >
+                {{ statsOpen.openIssues ? statsOpen.openIssues.medium : "-" }}
+                <div style="font-size: 14;">Medium</div>
+            </div>
+            <div class="column has-text-dark"  style="background: hsl(48, 100%, 67%); font-size: 36; text-align: center;">
+                {{ statsOpen.openIssues ? statsOpen.openIssues.low : "-" }}
+                <div style="font-size: 14;">Low</div>
+            </div>
+            <div class="column has-text-white" style="background: hsl(204, 86%, 53%); font-size: 36; text-align: center;">
+                {{ statsOpen.openIssues ? statsOpen.openIssues.informational : "-" }}
+                <div style="font-size: 14;">Informational</div>
+            </div>
         </div>
         <b-collapse class="card" :open=true animation="slide" aria-id="contentIdForA11y3">
             <div

--- a/src/report/listOfFindings/list.vue
+++ b/src/report/listOfFindings/list.vue
@@ -221,6 +221,9 @@ export default class ListOfFindings extends Vue {
   @Prop({ required: true })
   private atDate!: Date;
 
+  @Prop({ required: true })
+  private identifiers!: string;
+
   // Main List columns
 
   // Header for the Description column
@@ -362,7 +365,8 @@ export default class ListOfFindings extends Vue {
           size: perPage,
           minDate: this.minDate ? this.dateToStr(this.minDate) : "",
           maxDate: this.maxDate ? this.dateToStr(this.maxDate) : "",
-          atDate: this.atDate ? this.dateToStr(this.atDate) : ""
+          atDate: this.atDate ? this.dateToStr(this.atDate) : "",
+          identifiers: this.identifiers,
         };
         if (this.dateToStr(this.atDate) == this.dateToStr(new Date())) {
           findingsReq.atDate = undefined;
@@ -385,7 +389,8 @@ export default class ListOfFindings extends Vue {
           size: perPage,
           minDate: this.minDate ? this.dateToStr(this.minDate) : "",
           maxDate: this.maxDate ? this.dateToStr(this.maxDate) : "",
-          atDate: this.atDate ? this.dateToStr(this.atDate) : ""
+          atDate: this.atDate ? this.dateToStr(this.atDate) : "",
+          identifiers: this.identifiers,
         };
         if (this.dateToStr(this.atDate) == this.dateToStr(new Date())) {
           findingsReq.atDate = undefined;

--- a/src/report/report.vue
+++ b/src/report/report.vue
@@ -19,6 +19,11 @@ Copyright 2021 Adevinta
                 </span>
                 <span>{{ team }}</span>
               </h1>
+              <h1 id="team" class="subtitle">
+                <span class="icon is-small" style="margin-right:1.0em">
+                </span>
+                <span>{{ application }}</span>
+              </h1>
             </div>
             <div class="column is-4">
               <b-field label="Select a team" label-position="on-border" v-if="enableUserListTeams">
@@ -78,6 +83,7 @@ export default class LiveReport extends Vue {
    private errorMessage: string = "";
 
    private team: string = "";
+   private application: string = "";
    private teamId: string = "";
    private userApi?: UserApi;
    private teamsApi?: TeamsApi;
@@ -117,6 +123,9 @@ export default class LiveReport extends Vue {
          this.userApi,
          this.teamsApi
        );
+
+       var qparams = new URL(document.location.toString()).searchParams;
+       this.application = qparams.get('application') || ""
      } catch (err) {
        this.handleError(err);
      } finally {

--- a/src/services/vulcan-api/apis/FindingsApi.ts
+++ b/src/services/vulcan-api/apis/FindingsApi.ts
@@ -44,6 +44,7 @@ export interface FindingsFindFindingsFromAIssueRequest {
     issueId: string;
     teamId: string;
     atDate?: string;
+    identifiers?: string;
     maxDate?: string;
     maxScore?: number;
     minDate?: string;
@@ -58,6 +59,7 @@ export interface FindingsFindFindingsFromATargetRequest {
     targetId: string;
     teamId: string;
     atDate?: string;
+    identifiers?: string;
     maxDate?: string;
     maxScore?: number;
     minDate?: string;
@@ -77,6 +79,7 @@ export interface FindingsListFindingsRequest {
     teamId: string;
     atDate?: string;
     identifier?: string;
+    identifiers?: string;
     maxDate?: string;
     maxScore?: number;
     minDate?: string;
@@ -90,6 +93,7 @@ export interface FindingsListFindingsRequest {
 export interface FindingsListFindingsIssuesRequest {
     teamId: string;
     atDate?: string;
+    identifiers?: string;
     maxDate?: string;
     minDate?: string;
     page?: number;
@@ -101,6 +105,7 @@ export interface FindingsListFindingsIssuesRequest {
 export interface FindingsListFindingsTargetsRequest {
     teamId: string;
     atDate?: string;
+    identifiers?: string;
     maxDate?: string;
     minDate?: string;
     page?: number;
@@ -179,6 +184,10 @@ export class FindingsApi extends runtime.BaseAPI {
             queryParameters['atDate'] = requestParameters.atDate;
         }
 
+        if (requestParameters.identifiers !== undefined) {
+            queryParameters['identifiers'] = requestParameters.identifiers;
+        }
+
         if (requestParameters.maxDate !== undefined) {
             queryParameters['maxDate'] = requestParameters.maxDate;
         }
@@ -253,6 +262,10 @@ export class FindingsApi extends runtime.BaseAPI {
 
         if (requestParameters.atDate !== undefined) {
             queryParameters['atDate'] = requestParameters.atDate;
+        }
+
+        if (requestParameters.identifiers !== undefined) {
+            queryParameters['identifiers'] = requestParameters.identifiers;
         }
 
         if (requestParameters.maxDate !== undefined) {
@@ -371,6 +384,10 @@ export class FindingsApi extends runtime.BaseAPI {
             queryParameters['identifier'] = requestParameters.identifier;
         }
 
+        if (requestParameters.identifiers !== undefined) {
+            queryParameters['identifiers'] = requestParameters.identifiers;
+        }
+
         if (requestParameters.maxDate !== undefined) {
             queryParameters['maxDate'] = requestParameters.maxDate;
         }
@@ -443,6 +460,10 @@ export class FindingsApi extends runtime.BaseAPI {
             queryParameters['atDate'] = requestParameters.atDate;
         }
 
+        if (requestParameters.identifiers !== undefined) {
+            queryParameters['identifiers'] = requestParameters.identifiers;
+        }
+
         if (requestParameters.maxDate !== undefined) {
             queryParameters['maxDate'] = requestParameters.maxDate;
         }
@@ -505,6 +526,10 @@ export class FindingsApi extends runtime.BaseAPI {
 
         if (requestParameters.atDate !== undefined) {
             queryParameters['atDate'] = requestParameters.atDate;
+        }
+
+        if (requestParameters.identifiers !== undefined) {
+            queryParameters['identifiers'] = requestParameters.identifiers;
         }
 
         if (requestParameters.maxDate !== undefined) {

--- a/src/services/vulcan-api/apis/StatsApi.ts
+++ b/src/services/vulcan-api/apis/StatsApi.ts
@@ -49,6 +49,7 @@ export interface StatsMttrRequest {
 export interface StatsOpenRequest {
     teamId: string;
     atDate?: string;
+    identifiers?: string;
     maxDate?: string;
     minDate?: string;
 }
@@ -199,6 +200,10 @@ export class StatsApi extends runtime.BaseAPI {
 
         if (requestParameters.atDate !== undefined) {
             queryParameters['atDate'] = requestParameters.atDate;
+        }
+
+        if (requestParameters.identifiers !== undefined) {
+            queryParameters['identifiers'] = requestParameters.identifiers;
         }
 
         if (requestParameters.maxDate !== undefined) {


### PR DESCRIPTION
- Filter findings by a list of identifiers
- Implement an `application` parameter, which will be used to name the group of assets being shown
- Add labels to the "Severity Bar" scores

Example:
`https://vulcan.example.com/report/report.html?team_id=4af98671-1648-4bf8-adba-001115277e67&application=My-App&identifiers=foo.com,bar.com,qux.com`