### PR TITLE
Fix date shortcut links behaviour when mode selected is 'open'

### DIFF
--- a/src/report/home/home.vue
+++ b/src/report/home/home.vue
@@ -844,7 +844,7 @@ export default class Home extends Vue {
   }
 
   onClickDateShortcut(range) {
-    if (this.modeSelect=='diff' || this.modeSelect=='fixed') {
+    if (this.modeSelect=='open' || this.modeSelect=='fixed') {
       this.maxDate=new Date();
       this.minDate=new Date(this.maxDate);
       if (range=='7days') {


### PR DESCRIPTION
This PR corrects the click event for date shortcuts when the mode selected is "open" (New Findings).