### PR TITLE
Add Asset Info link for report's assets and issues tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3541,6 +3541,16 @@
       "integrity": "sha512-1QL4544moEsDVH9T/l6Cemov/37iv1RtoKf7NJ04A60+4MREXNfx/QvavbH6QoGdsD4N4Mwy49cmaINR/o2mdg==",
       "dev": true
     },
+    "clipboard": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.8.tgz",
+      "integrity": "sha512-Y6WO0unAIQp5bLmk1zdThRhgJt/x3ks6f30s3oE3H1mgIEU33XyQjEf8gsf6DxC7NPX8Y1SsNWjUjL/ywLnnbQ==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
@@ -4317,6 +4327,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -5098,6 +5113,14 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "graceful-fs": {
@@ -11989,6 +12012,11 @@
         }
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -12837,6 +12865,11 @@
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -13278,6 +13311,15 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
+    },
+    "vue-json-viewer": {
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/vue-json-viewer/-/vue-json-viewer-2.2.19.tgz",
+      "integrity": "sha512-zXbnYwADWB7THcn17HBw9PhyXZDgvBFtfG0QE1cASr2vzXeTPtIKp0vkjuDdxOcvlHKU5Sj1uaLYiMCX+ULPOQ==",
+      "requires": {
+        "clipboard": "^2.0.4",
+        "vue": "^2.6.9"
+      }
     },
     "vue-property-decorator": {
       "version": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "vue": "^2.6.12",
     "vue-class-component": "^7.2.6",
     "vue-hot-reload-api": "^2.3.4",
+    "vue-json-viewer": "^2.2.19",
     "vue-property-decorator": "^9.0.2",
     "vue-router": "^3.4.9",
     "vue-showdown": "^2.4.1",

--- a/src/report/assetInfoForm/assetInfoForm.vue
+++ b/src/report/assetInfoForm/assetInfoForm.vue
@@ -1,0 +1,103 @@
+<!--
+Copyright 2021 Adevinta
+-->
+
+<template>
+  <div class="modal-card">
+    <header class="modal-card-head">
+      <p class="modal-card-title">Asset Info</p>
+      <button type="button" class="delete" @click="$parent.close()" />
+    </header>
+    <section class="modal-card-body">
+        <ErrorDialog :show="showError" :message="errorMessage"></ErrorDialog>
+          <json-viewer :expand-depth=4 :value="data"></json-viewer>
+    </section>
+  </div>
+</template>
+
+<script lang="ts">
+// Import modules
+import { Vue, Component, Prop } from "vue-property-decorator";
+import loadConfig, { Config } from "../../common/config";
+import tokenProvider from "../../common/token";
+import teamID from "../../common/team";
+import ErrorDialog from "../../components/error.vue";
+import JsonViewer from 'vue-json-viewer'
+import {
+  Configuration as ApiConf,
+  ConfigurationParameters
+} from "../../services/vulcan-api";
+import {
+  AssetsApi,
+  AssetsListRequest,
+} from "../../services/vulcan-api/apis";
+import {
+  Listassetentry,
+} from "../../services/vulcan-api/models";
+
+@Component({
+  name: "AssetInfoForm",
+  components: {
+    ErrorDialog,
+    JsonViewer,
+  }
+})
+
+export default class AssetInfoForm extends Vue {
+  private assetsApi!: AssetsApi;
+  private data: Listassetentry[] = [];
+
+  @Prop({ required: true, default: "" })
+  private assetIdentifier!: string;
+
+  @Prop({ required: true, default: "" })
+  private teamId!: string;
+
+  private showError: boolean = false;
+  private errorMessage: string = "";
+
+  async mounted() {
+    try {
+      // Load the config
+      const conf = await loadConfig();
+      const tProvider = tokenProvider(conf);
+      const c: ConfigurationParameters = {
+        apiKey: tProvider,
+        basePath: conf.apiUrl
+      };
+
+      // Build the api clients
+      const apiConfg = new ApiConf(c);
+      this.assetsApi = new AssetsApi(apiConfg);
+
+      // Retrieve assets data by identifier
+      const assetReq: AssetsListRequest = {
+          teamId: this.teamId,
+          identifier: this.assetIdentifier,
+      }
+      this.data = await this.assetsApi.assetsList(assetReq);
+    } catch (err) {
+      this.handleError(err);
+    } 
+  }
+
+  private handleError(err: any) {
+    if (err instanceof Response) {
+      console.log(`${err.status} ": " ${err.statusText}`);
+      this.errorMessage = `unexpected error calling vulcan api, status code: ${
+        err.status
+      }`;
+      this.showError = true;
+      return;
+    }
+    if (err instanceof Error) {
+      console.log(`error: " ${err.message}`);
+      this.errorMessage = `unexpected error: ${err.message}`;
+      this.showError = true;
+      return;
+    }
+    console.log(`unexpected error: " ${JSON.stringify(err)}`);
+    this.showError = true;
+  }
+}
+</script>

--- a/src/report/tableAssets/tableAssets.vue
+++ b/src/report/tableAssets/tableAssets.vue
@@ -38,6 +38,12 @@ Copyright 2021 Adevinta
             v-bind:class="severityStyle(propsMainList.row.maxScore)" style="width: 70"
           > {{ severityText(propsMainList.row.maxScore) }}</span>
         </b-table-column>
+
+        <b-table-column centered width="100" field="assetInfo" label="Asset Info">
+          <b-button type="is-info is-text is-small"  inverted @click.stop="showAssetInfo(propsMainList.row.identifier)">
+            <b-icon pack="mdi" icon="information"></b-icon>
+          </b-button>
+        </b-table-column>
       </template>
 
       <template slot="detail" slot-scope="propsDetail">
@@ -213,12 +219,15 @@ import teamID from "../../common/team";
 
 //@ts-ignore
 import { Table } from "buefy";
+import { BModalComponent } from "buefy/types/components";
+import AssetInfoForm from "../assetInfoForm/assetInfoForm.vue";
 
 @Component({
   name: "TableAssets",
-  components: {}
+  components: {
+      AssetInfoForm,
+  }
 })
-
 export default class TableAssets extends Vue {
   private apiUrl: string = "";
   private teamId: string = "";
@@ -251,6 +260,8 @@ export default class TableAssets extends Vue {
 
   private assetsList: Array<FindingsTarget> = [];
   private assetsListTotal: number = 0;
+
+  private assetsInfoModal!: BModalComponent
 
   private loading: boolean = false;
 
@@ -459,6 +470,28 @@ export default class TableAssets extends Vue {
     const day = new Intl.DateTimeFormat("en", { day: "2-digit" }).format(date);
 
     return year + "-" + month + "-" + day;
+  }
+
+  private showAssetInfo(assetIdentifier: string) {
+    this.assetsInfoModal = this.$buefy.modal.open({
+            parent: this,
+            component: AssetInfoForm,
+            hasModalCard: true,
+            fullScreen: false,
+            trapFocus: true,
+            props: {
+              teamId: this.teamId,
+              assetIdentifier: assetIdentifier,
+            },
+            events: {
+                'handleerror': (err: Error) =>{
+                    this.$emit('handleerror', err);
+                },
+                'close': () => {
+                    this.assetsInfoModal.close();
+                }
+            },
+        });
   }
 
   private showcursor() {

--- a/src/report/tableIssues/tableIssues.vue
+++ b/src/report/tableIssues/tableIssues.vue
@@ -134,6 +134,13 @@ Copyright 2021 Adevinta
                         v-bind:class="severityStyle(propsTargets.row.maxScore)" style="width: 70"
                       >{{ severityText(propsTargets.row.maxScore) }}</span>
                     </b-table-column>
+
+                    <!-- Asset Info -->
+                    <b-table-column centered width="100" field="assetInfo" label="Asset Info">
+                      <b-button type="is-info is-text is-small"  inverted @click.stop="showAssetInfo(propsTargets.row.identifier)">
+                        <b-icon pack="mdi" icon="information"></b-icon>
+                      </b-button>
+                    </b-table-column>
                   </template>
 
                   <!-- Resources table -->
@@ -224,10 +231,14 @@ import teamID from "../../common/team";
 
 //@ts-ignore
 import { Table } from "buefy";
+import { BModalComponent } from "buefy/types/components";
+import AssetInfoForm from "../assetInfoForm/assetInfoForm.vue";
 
 @Component({
   name: "TableIssues",
-  components: {}
+  components: {
+    AssetInfoForm,
+  }
 })
 
 export default class TableIssues extends Vue {
@@ -262,6 +273,8 @@ export default class TableIssues extends Vue {
 
   private issuesList: Array<FindingsIssue> = [];
   private issuesListTotal: number = 0;
+
+  private assetsInfoModal!: BModalComponent
 
   private loading: boolean = false;
 
@@ -495,6 +508,28 @@ export default class TableIssues extends Vue {
 
     //@ts-ignore
     this.$refs["tableIssuesDetails-" + issueId].toggleDetails(row);
+  }
+
+  private showAssetInfo(assetIdentifier: string) {
+    this.assetsInfoModal = this.$buefy.modal.open({
+            parent: this,
+            component: AssetInfoForm,
+            hasModalCard: true,
+            fullScreen: false,
+            trapFocus: true,
+            props: {
+              teamId: this.teamId,
+              assetIdentifier: assetIdentifier,
+            },
+            events: {
+                'handleerror': (err: Error) =>{
+                    this.$emit('handleerror', err);
+                },
+                'close': () => {
+                    this.assetsInfoModal.close();
+                }
+            },
+        });
   }
 
   dateToStr(date: Date): string {


### PR DESCRIPTION
This PR adds a new assets info icon for every asset row in the reports issues and assets tables.

This "info" link opens a new modal window containing a beautified JSON which contains the whole data stored for the asset in Vulcan API DB:
![Screenshot from 2021-10-04 14-27-59](https://user-images.githubusercontent.com/6529572/135851398-86b7f298-84d8-47ee-a815-01423687635d.png)

As mentioned, the asset info link/icon is shown on both assets and issues tables for the rows on which the asset identifier is listed.
Example for the assets table:
![Screenshot from 2021-10-04 14-19-46](https://user-images.githubusercontent.com/6529572/135851634-77c3eb88-3644-4150-92a6-e83eb3167845.png)

Example for the issues table:
![Screenshot from 2021-10-04 14-31-48](https://user-images.githubusercontent.com/6529572/135851814-d7493fa3-72dc-4ace-93ce-75f70c91283f.png)

**On another note...**
Also feedback is welcome in regard of possible modifications for icons to use in the labels filter.
Original design looks like (outline version):
![Screenshot from 2021-10-04 14-19-03](https://user-images.githubusercontent.com/6529572/135852051-a516eed4-9d46-4d50-90f5-b7e806340b59.png)
Alternative design looks like:
![Screenshot from 2021-10-04 14-19-33](https://user-images.githubusercontent.com/6529572/135852093-bad98762-768a-4cad-9692-e655c1589c6e.png)

Any combination between them is also valid.

My personal preference is to keep the original design (the outlined version), as in that way also the "informational" and "asset information" icons do not match, but as mentioned feedback is welcome.

