### PR TITLE
Fix bug when getting the hostname of an invalid url

### DIFF
--- a/src/report/utils/utils.ts
+++ b/src/report/utils/utils.ts
@@ -57,8 +57,14 @@ export function severityStyle(score: number) {
   }
   
   export function urlDomain(url) {
-    const url = new URL(url);
-    return url.hostname;
+    try {
+      const url = new URL(url);
+      return url.hostname;
+    }
+    catch {
+      return ""
+    }
+
   }
 
   export class propsFindingDetailTemplate {

--- a/src/report/utils/utils.ts
+++ b/src/report/utils/utils.ts
@@ -61,7 +61,7 @@ export function severityStyle(score: number) {
       return (new URL(url)).hostname;
     }
     catch {
-      return url
+      return ""
     }
 
   }

--- a/src/report/utils/utils.ts
+++ b/src/report/utils/utils.ts
@@ -58,11 +58,10 @@ export function severityStyle(score: number) {
   
   export function urlDomain(url) {
     try {
-      const url = new URL(url);
-      return url.hostname;
+      return (new URL(url)).hostname;
     }
     catch {
-      return ""
+      return url
     }
 
   }


### PR DESCRIPTION
This PR fixes a bug when getting the hostname of an URL that is preventing the expansion of some findings.