### PR TITLE
Use team_id instead of tag for FindingOverwrites

### DIFF
--- a/src/services/vulcan-api/models/FindingOverwrite.ts
+++ b/src/services/vulcan-api/models/FindingOverwrite.ts
@@ -60,7 +60,7 @@ export interface FindingOverwrite {
      * @type {string}
      * @memberof FindingOverwrite
      */
-    team_id?: string;
+    teamId?: string;
     /**
      * User who requested the finding overwrite
      * @type {string}
@@ -85,7 +85,7 @@ export function FindingOverwriteFromJSONTyped(json: any, ignoreDiscriminator: bo
         'notes': !exists(json, 'notes') ? undefined : json['notes'],
         'status': !exists(json, 'status') ? undefined : json['status'],
         'statusPrevious': !exists(json, 'status_previous') ? undefined : json['status_previous'],
-        'team_id': !exists(json, 'team_id') ? undefined : json['team_id'],
+        'teamId': !exists(json, 'team_id') ? undefined : json['team_id'],
         'user': !exists(json, 'user') ? undefined : json['user'],
     };
 }
@@ -105,7 +105,7 @@ export function FindingOverwriteToJSON(value?: FindingOverwrite | null): any {
         'notes': value.notes,
         'status': value.status,
         'status_previous': value.statusPrevious,
-        'team_id': value.team_id,
+        'team_id': value.teamId,
         'user': value.user,
     };
 }

--- a/src/services/vulcan-api/models/FindingOverwrite.ts
+++ b/src/services/vulcan-api/models/FindingOverwrite.ts
@@ -56,11 +56,11 @@ export interface FindingOverwrite {
      */
     statusPrevious?: string;
     /**
-     * The tag associated to the user/team who requested this overwrite
+     * The ID associated to the team who requested this overwrite
      * @type {string}
      * @memberof FindingOverwrite
      */
-    tag?: string;
+    team_id?: string;
     /**
      * User who requested the finding overwrite
      * @type {string}
@@ -85,7 +85,7 @@ export function FindingOverwriteFromJSONTyped(json: any, ignoreDiscriminator: bo
         'notes': !exists(json, 'notes') ? undefined : json['notes'],
         'status': !exists(json, 'status') ? undefined : json['status'],
         'statusPrevious': !exists(json, 'status_previous') ? undefined : json['status_previous'],
-        'tag': !exists(json, 'tag') ? undefined : json['tag'],
+        'team_id': !exists(json, 'team_id') ? undefined : json['team_id'],
         'user': !exists(json, 'user') ? undefined : json['user'],
     };
 }
@@ -105,7 +105,7 @@ export function FindingOverwriteToJSON(value?: FindingOverwrite | null): any {
         'notes': value.notes,
         'status': value.status,
         'status_previous': value.statusPrevious,
-        'tag': value.tag,
+        'team_id': value.team_id,
         'user': value.user,
     };
 }


### PR DESCRIPTION
Adapt client models to [Vulcan API PR#61](https://github.com/adevinta/vulcan-api/pull/61), specifically commit [3ee472ba1ca8d2204fdacf3ee516769434994cbc](https://github.com/adevinta/vulcan-api/pull/61/commits/3ee472ba1ca8d2204fdacf3ee516769434994cbc).