### PR TITLE
Automatically redirect when user session is expired/there is no session

### DIFF
--- a/src/assets/common.js
+++ b/src/assets/common.js
@@ -109,25 +109,9 @@ function baseQueryParams() {
 
 function showLogin(cfg) {
     hideLoading();
-    let team = teamID();
-    let scan = scanID();
-    if (!scan || !team) {
-        $("#sessionExpiredBody").html(`Your session expired or you don't have permission for this team.
-        </BR>
-        Can not generate a login link this time because the current
-        url does not contain required information.
-        </BR>
-        You can login in vulcan again by clicking in the full report link present in a vulcan report
-        email.
-        `)
-    } else {
-        let url = cfg.api_url;
-        url = url + "report"
-        url = url + `?team_id=${team}&scan_id=${scan}`
-        $("#linkRelogin").attr("href", url)
-    }
-    $("#main").remove();
-    $("#sessionExpired").css("display", "")
+    let url = cfg.api_url;
+    url = url + `login?redirect_to=${window.location}`
+    window.location.href = url;
 }
 
 function teamID() {

--- a/src/assets/common.js
+++ b/src/assets/common.js
@@ -109,9 +109,35 @@ function baseQueryParams() {
 
 function showLogin(cfg) {
     hideLoading();
-    let url = cfg.api_url;
-    url = url + `login?redirect_to=${window.location}`
-    window.location.href = url;
+
+    // If user has already been redirected and session is still
+    // invalid, redirect user to main page. Otherwise redirect
+    // user to requested page.
+    let query = window.location.search.substring(1);
+    let isredirect = isRedirect(query);
+    let redirectTo = window.location.toString().split("#")[0];
+
+    if (!isDecoded(redirectTo)) redirectTo = decodeURIComponent(redirectTo);
+    if (isredirect) redirectTo = "/";
+    else redirectTo = redirectTo + "&redirect=true";
+
+    window.location.href = cfg.api_url + `login?redirect_to=${encodeURIComponent(redirectTo)}`;
+}
+
+function isRedirect(query) {
+    let vars = query.split('&');
+    for (let i = 0; i < vars.length; i++) {
+        let kv = vars[i].split('=');
+        if (decodeURIComponent(kv[0]) == "redirect" && decodeURIComponent(kv[1]) == "true") {
+            return true;
+        }
+    }
+    return false;
+}
+
+function isDecoded(uri) {
+    uri = uri || '';
+    return uri === decodeURIComponent(uri);
 }
 
 function teamID() {

--- a/src/assets/common.js
+++ b/src/assets/common.js
@@ -113,14 +113,12 @@ function showLogin(cfg) {
     // If user has already been redirected and session is still
     // invalid, redirect user to main page. Otherwise redirect
     // user to requested page.
-    let query = window.location.search;
-    if (query.length) query = query.substring(1);
-    let isredirect = isRedirect(query);
     let redirectTo = window.location.toString().split("#")[0];
-
     if (!isDecoded(redirectTo)) redirectTo = decodeURIComponent(redirectTo);
-    if (isredirect) redirectTo = "/";
-    else redirectTo = redirectTo + "&redirect=true";
+
+    let query = window.location.search;
+    if (isRedirect(query)) redirectTo = "/";
+    else redirectTo += query.length ? "&redirect=true" : "?redirect=true";
 
     window.location.href = cfg.api_url + `login?redirect_to=${encodeURIComponent(redirectTo)}`;
 }

--- a/src/assets/common.js
+++ b/src/assets/common.js
@@ -113,7 +113,8 @@ function showLogin(cfg) {
     // If user has already been redirected and session is still
     // invalid, redirect user to main page. Otherwise redirect
     // user to requested page.
-    let query = window.location.search.substring(1);
+    let query = window.location.search;
+    if (query.length) query = query.substring(1);
     let isredirect = isRedirect(query);
     let redirectTo = window.location.toString().split("#")[0];
 

--- a/src/common.js
+++ b/src/common.js
@@ -140,9 +140,35 @@ function verifyConfig(cfg) {
 
 function showSessionExpired(elem, cfg) {
   hideLoading();
-  let url = cfg.api_url;
-  url = url + `login?redirect_to=${window.location}`
-  window.location.href = url;
+
+  // If user has already been redirected and session is still
+  // invalid, redirect user to main page. Otherwise redirect
+  // user to requested page.
+  let query = window.location.search.substring(1);
+  let isredirect = isRedirect(query);
+  let redirectTo = window.location.toString().split("#")[0];
+
+  if (!isDecoded(redirectTo)) redirectTo = decodeURIComponent(redirectTo);
+  if (isredirect) redirectTo = "/";
+  else redirectTo = redirectTo + "&redirect=true";
+
+  window.location.href = cfg.api_url + `login?redirect_to=${encodeURIComponent(redirectTo)}`;
+}
+
+function isRedirect(query) {
+  let vars = query.split('&');
+  for (let i = 0; i < vars.length; i++) {
+    let kv = vars[i].split('=');
+    if (decodeURIComponent(kv[0]) == "redirect" && decodeURIComponent(kv[1]) == "true") {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isDecoded(uri) {
+  uri = uri || '';
+  return uri === decodeURIComponent(uri);
 }
 
 function showTeam(elem, name) {

--- a/src/common.js
+++ b/src/common.js
@@ -36,18 +36,6 @@ const errorComponent = $(`
       </article>
 `)
 
-const sessionExpiredComponent = $(`
-<article id="sessionExpired" class="message is-danger" style="display: none">
-    <div class="message-header has-text-centered">
-      <p>Session expired</p>
-    </div>
-    <div id="sessionExpiredBody" class="message-body has-text-centered">
-      Your session expired or you don't have permission for this team.
-      <BR>
-      <a id="linkRelogin" href="" target="_self">Log in to vulcan</a>
-    </div>
-  </article>`)
-
 const warningDialogComponent = $(`<article id="warningDialog" class="message is-warning" style="display: none">
       <div class="message-header">
         <p>Read only access</p>
@@ -150,18 +138,11 @@ function verifyConfig(cfg) {
   }
 }
 
-let sessionExpiredAdded = false
-
 function showSessionExpired(elem, cfg) {
-  if (!sessionExpiredAdded) {
-    elem.prepend(sessionExpiredComponent)
-    sessionExpiredAdded = true
-  }
   hideLoading();
   let url = cfg.api_url;
   url = url + `login?redirect_to=${window.location}`
-  $("#linkRelogin").attr("href", url)
-  $("#sessionExpired").css("display", "")
+  window.location.href = url;
 }
 
 function showTeam(elem, name) {

--- a/src/common.js
+++ b/src/common.js
@@ -144,14 +144,12 @@ function showSessionExpired(elem, cfg) {
   // If user has already been redirected and session is still
   // invalid, redirect user to main page. Otherwise redirect
   // user to requested page.
-  let query = window.location.search;
-  if (query.length) query = query.substring(1);
-  let isredirect = isRedirect(query);
   let redirectTo = window.location.toString().split("#")[0];
-
   if (!isDecoded(redirectTo)) redirectTo = decodeURIComponent(redirectTo);
-  if (isredirect) redirectTo = "/";
-  else redirectTo = redirectTo + "&redirect=true";
+
+  let query = window.location.search;
+  if (isRedirect(query)) redirectTo = "/";
+  else redirectTo += query.length ? "&redirect=true" : "?redirect=true";
 
   window.location.href = cfg.api_url + `login?redirect_to=${encodeURIComponent(redirectTo)}`;
 }

--- a/src/common.js
+++ b/src/common.js
@@ -144,7 +144,8 @@ function showSessionExpired(elem, cfg) {
   // If user has already been redirected and session is still
   // invalid, redirect user to main page. Otherwise redirect
   // user to requested page.
-  let query = window.location.search.substring(1);
+  let query = window.location.search;
+  if (query.length) query = query.substring(1);
   let isredirect = isRedirect(query);
   let redirectTo = window.location.toString().split("#")[0];
 

--- a/src/components/session.vue
+++ b/src/components/session.vue
@@ -4,15 +4,6 @@ Copyright 2021 Adevinta
 
 <template>
   <div>
-    <article class="message is-danger" :style="errorStyle()">
-      <div class="message-header has-text-centered">
-        <p>Session expired</p>
-      </div>
-      <div id="sessionExpiredBody" class="message-body has-text-centered">
-        <br />Your session expired or you don't have permission for this team.
-        <a target="_self" :href="addr()">Log in to vulcan</a>
-      </div>
-    </article>
     <div :style="contentStyle()">
       <slot></slot>
     </div>
@@ -20,7 +11,7 @@ Copyright 2021 Adevinta
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from "vue-property-decorator";
+import { Component, Prop, Vue, Watch } from "vue-property-decorator";
 
 @Component({
   name: "Session"
@@ -33,21 +24,21 @@ export default class Session extends Vue {
   @Prop({ required: true, default: "" })
   apiUrl!: string;
 
-  //Private methods.
-  private isVisible(): boolean {
-    return this.show;
-  }
-
-  private errorStyle(): any {
-    const display = this.isVisible() ? "" : "none";
-    const s: any = { display: display };
-    return s;
-  }
-
   private contentStyle(): any {
     const display = !this.show ? "" : "none";
     const s: any = { display: display };
     return s;
+  }
+
+  @Watch('show')
+  async onShowChange(value: boolean, oldValue: boolean) {
+    try {
+      if (value == true) {
+        window.location.href = this.addr();
+      }
+    } catch (err) {
+      this.$emit('handleerror', err);
+    }
   }
 
   private addr(): string {

--- a/src/components/session.vue
+++ b/src/components/session.vue
@@ -47,11 +47,11 @@ export default class Session extends Vue {
     // user to requested page.
     var query: string = window.location.search.substring(1);
     var isRedirect: boolean = this.isRedirect(query);
-    var redirectTo: string = window.location.toString();
+    var redirectTo: string = window.location.toString().split("#")[0];
 
     if (!this.isDecoded(redirectTo)) redirectTo = decodeURIComponent(redirectTo);
     if (isRedirect) redirectTo = "/";
-    else redirectTo = window.location.toString() + "&redirect=true";
+    else redirectTo = redirectTo + "&redirect=true";
     
     return `${this.apiUrl}/login?redirect_to=${encodeURIComponent(redirectTo)}`;
   }

--- a/src/components/session.vue
+++ b/src/components/session.vue
@@ -45,15 +45,13 @@ export default class Session extends Vue {
     // If user has already been redirected and session is still
     // invalid, redirect user to main page. Otherwise redirect
     // user to requested page.
-    var query: string = window.location.search;
-    if (query.length) query = query.substring(1);
-    var isRedirect: boolean = this.isRedirect(query);
     var redirectTo: string = window.location.toString().split("#")[0];
-
     if (!this.isDecoded(redirectTo)) redirectTo = decodeURIComponent(redirectTo);
-    if (isRedirect) redirectTo = "/";
-    else redirectTo = redirectTo + "&redirect=true";
-    
+
+    var query: string = window.location.search;
+    if (this.isRedirect(query)) redirectTo = "/";
+    else redirectTo += query.length ? "&redirect=true" : "?redirect=true";
+
     return `${this.apiUrl}/login?redirect_to=${encodeURIComponent(redirectTo)}`;
   }
 

--- a/src/components/session.vue
+++ b/src/components/session.vue
@@ -45,7 +45,8 @@ export default class Session extends Vue {
     // If user has already been redirected and session is still
     // invalid, redirect user to main page. Otherwise redirect
     // user to requested page.
-    var query: string = window.location.search.substring(1);
+    var query: string = window.location.search;
+    if (query.length) query = query.substring(1);
     var isRedirect: boolean = this.isRedirect(query);
     var redirectTo: string = window.location.toString().split("#")[0];
 

--- a/src/components/session.vue
+++ b/src/components/session.vue
@@ -46,7 +46,24 @@ export default class Session extends Vue {
     if (this.isDecoded(redirectTo)) {
       redirectTo = encodeURIComponent(window.location.toString());
     }
-    return `${this.apiUrl}/login?redirect_to=${redirectTo}`;
+    // If user has already been redirected and session is still
+    // invalid, redirect user to main page. Otherwise redirect
+    // user to currently reqested page.
+    var query: string = window.location.search.substring(1);
+    window.alert(query);
+    if (this.isRedirect(query)) return `${this.apiUrl}/login`;
+    return `${this.apiUrl}/login?redirect_to=${redirectTo}&redirect=true`;
+  }
+
+  private isRedirect(query: string): boolean {
+    var vars: string[] = query.split('&');
+    for (let i = 0; i < vars.length; i++) {
+      var kv: string[] = vars[i].split('=');
+      if (decodeURIComponent(kv[0]) == "redirect" && decodeURIComponent(kv[1]) == "true") {
+        return true;
+      }
+    }
+    return false;
   }
 
   private isDecoded(uri: string): boolean {


### PR DESCRIPTION
This PR modifies the implementation when an invalid user session is detected in the Vulcan UI in order to, instead of asking the user to follow a link in order to login, automatically try to log in the user, this is done in the following way:
- If the user has a valid session in the IdP, a session cookie will be issued with no more action from the end user.
- If the user does not have a valid session in the IdP, the user will be redirected to the IdP in order to log in and if that action is successful then a session cookie will be issued for Vulcan
- If the user has a valid session in Vulcan but does not have permission to access the requested resource, he/she will be redirected to the main Vulcan page.