### PR TITLE
Validate malformed ARN strings.

### DIFF
--- a/src/assets/add-assets.js
+++ b/src/assets/add-assets.js
@@ -5,6 +5,7 @@ Copyright 2021 Adevinta
 import * as api from '../vulcan-api'
 import * as common from './common'
 import "./import-jquery"
+import {validateAsset} from "./common";
 
 var client;
 var config;
@@ -64,6 +65,10 @@ async function addAssets(client, config, assets, id) {
 
     var assetArray = [];
     for (var i = 0; i < assets.length; i++) {
+        if (!validateAsset(assets[i])){
+            common.showError(`The identifier of the asset ${assets[i]} doesn't have a valid format.`);
+            return;
+        }
         let asset = {
             identifier: assets[i]
         }

--- a/src/assets/common.js
+++ b/src/assets/common.js
@@ -152,6 +152,14 @@ function scanID() {
     return scanID;
 }
 
+function validateAsset(asset){
+    if (asset.startsWith("arn:")){
+        const arnRegex =/^(arn:(?:aws|aws-cn|aws-us-gov):([\w-]+):([a-z]+-[a-z]+-\d)?:(\d{0,12}):([\w-]*)(\/?[\w-]*)(\/.*)?.*)$/
+        return arnRegex.test(asset);
+    }
+    return true
+}
+
 export {
     config,
     showError,
@@ -163,5 +171,6 @@ export {
     hideLoading,
     showTeam,
     askConfirm,
-    baseQueryParams
+    baseQueryParams,
+    validateAsset
 }


### PR DESCRIPTION
A user can add an asset through the UI (and hence through the API) with a malformed identifier, for example, an AWS account ARN with a space in the middle:

`arn:aws:iam:: 012345678900:root`

This causes the outbox CDC to stop working as the subsequent request to the vulnerabilitydb-api to propagate the action fails:
```
component=CDC error=\"<html><body><h1>400 Bad request</h1>\\nYour browser sent an invalid request.\\n</body></html>\\n\" id=93995f78-025e-413e-99d4-d047a4198bd7 action=DeleteAsset retries=20\n","stream":"stderr","time":"2023-05-03T09:05:32.744982511Z"
```

In this PR we validate the ARN string before sending a requests to vulcan-api with a malformed ARN.

