### PR TITLE
Always show team selector on home

### DIFF
--- a/src/report/home/home.vue
+++ b/src/report/home/home.vue
@@ -394,9 +394,12 @@ export default class Home extends Vue {
     } catch (err) {
       this.$emit('handleerror', err);
     } finally {
-      this.$emit('toggleUserListTeams', true);
       this.loading = false;
     }
+  }
+
+  async activated() {
+    this.$emit('toggleUserListTeams', true);
   }
 
   private async loadLabels(findingsApi: FindingsApi) {


### PR DESCRIPTION
When navigating to a finding we hide the team selector.
When we come back to the reports page it keeps hidden, but it shouldn't

This pr ensures that every time the home component is activated the team selector is visible.
